### PR TITLE
Admin Panel Fixes

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>TransitNetwork</title>
+    <title><%= Setting.site_name %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
     <%= stylesheet_link_tag "application" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,6 +21,9 @@
 		<li><%= link_to('All Lines', lines_path) %> </li>
 		<li><%= link_to('About', page_path(:page_name => 'about')) %></li>
 		<% if current_user %>
+			<% if current_user.admin %>
+				<li><%= link_to('Site Settings', '/settings') %></li>
+			<% end %>
 			<li><%= link_to('Favorite Stops', favorites_path) %></li>
 			<li><%= link_to('Log Out', destroy_user_session_path, :method => :delete) %></li>
 		<% else %>


### PR DESCRIPTION
This fixes the following issue with titles:

![screenshot from 2017-11-21 08-58-03](https://user-images.githubusercontent.com/3187531/33079029-1d3c7c64-ce9a-11e7-8bce-da3bd2d8c1c3.png)

This was caused by the `<title>` tag not being dynamically loaded and being hardcoded as Transit Network.

I also added a link to the site settings panel for admin users, like so:

![screenshot from 2017-11-21 09-01-09](https://user-images.githubusercontent.com/3187531/33079171-86c913cc-ce9a-11e7-966e-b3e630824604.png)
