### PR TITLE
Refactor Code References from Transit Network to Caravan

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In the future we hope to expand the functionality of Caravan by:
 
   * Creating an accountability system that will track an individual user's history of reports and closing of other user's reports. Distribute some form of punishment if logs suggest abuse of the platform.
 
-  * Consistently resolve bugs in the code as they appear over the development process. Unresolved issues are logged on [GitHub](https://github.com/rjaltman/Transit-Network/issues)
+  * Consistently resolve bugs in the code as they appear over the development process. Unresolved issues are logged on [GitHub](https://github.com/CaravanTransit/Caravan-App/issues)
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Transit Network [![Build Status](https://travis-ci.org/TransitNetworkGroup/Transit-Network.svg?branch=master)](https://travis-ci.org/vkoves/Transit-Network)
+# Caravan [![Build Status](https://api.travis-ci.org/CaravanTransit/Caravan-App.svg?branch=master)](https://travis-ci.org/CaravanTransit/Caravan-App)
 
-Transit Network is a platform for collective commuters to inquire and report on the status and structure of public transportation stations and lines. Behind the scenes, TransitNetwork is an open-source framework that facilitates efficient implementation of any major transit system that provides their GTFS formatted information. This adaptability to any transportation network provides the potential for an extensive network of locations within one centralized package where users and contributors can take better advantage of transportation resources. Presently, these benefits are products of TransitNetwork's ability to:
-  
+Caravan is a platform for collective commuters to inquire and report on the status and structure of public transportation stations and lines. Behind the scenes, Caravan is an open-source framework that facilitates efficient implementation of any major transit system that provides their GTFS formatted information. This adaptability to any transportation network provides the potential for an extensive network of locations within one centralized package where users and contributors can take better advantage of transportation resources. Presently, these benefits are products of Caravan's ability to:
+
   * Process GTFS formatted data and output accurate details regarding scheduling, transportation units, and locations.
 
-  * Act as a community forum where peers can report issues regarding discrepancies in the transit system that are publicly visible to other peers. These issues are likewise marked resolved by future users after the issue has dissipated. 
+  * Act as a community forum where peers can report issues regarding discrepancies in the transit system that are publicly visible to other peers. These issues are likewise marked resolved by future users after the issue has dissipated.
 
   * Track location which allows for automated presentation of the nearest stops and lines of transportation relative to a user's position.
 
@@ -12,7 +12,7 @@ Transit Network is a platform for collective commuters to inquire and report on 
 
 <br>
 
-In the future we hope to expand the functionality of TransitNetwork by:
+In the future we hope to expand the functionality of Caravan by:
 
   * Analyzing issues and their effect on a user's commute. From there, suggest alternative routes that improve efficiency.
 
@@ -28,9 +28,9 @@ In the future we hope to expand the functionality of TransitNetwork by:
 
 <br>
 
-## Using TransitNetwork
- 
- TransitNetwork's user interaction occurs through a mobile-oriented website that allows users to view recent reported issues of nearby stops and transportation units. 
+## Using Caravan
+
+ Caravan's user interaction occurs through a mobile-oriented website that allows users to view recent reported issues of nearby stops and transportation units.
 
  [//]: # (Homescreen w/o account photo TBD)
 
@@ -46,24 +46,24 @@ In the future we hope to expand the functionality of TransitNetwork by:
  The report page has a sequential selection order starting with the transportation line being chosen first. Based on which line is chosen, a list of all the stops on that line are listed and can be selected as an origin of an issue. From there, a user can classify the issue as a 'type' and give a description explaining the details.
 
 <br>
-  
+
 ## BUILD/INSTALLATION INSTRUCTIONS
   * Ruby on Rails v2.3.0 and Other Packages
     * All necessary packages for running this software are provided in the GEMFILE included in the source-code. Use the command:
 
       ```
       $ bundle install
-      ``` 
-    
+      ```
+
       to install all packages listed.
-   
+
   * Local Testing
     * Navigate to root directory
-   
+
    ```
    rails server
    ```
-   
+
     * Connect to Localhost:3000 on your browser
 
 ## Contributor Guide
@@ -73,16 +73,16 @@ To learn more about how to contribute, check out [our contribution guidelines](C
 To add a new modular setting to the settings panel (`/settings`), add it as a default in `config/app.yml` and then add the display name of the attribute in
 `config/locales/en.yml` under `en.settings.attributes.{{new_setting_name}}.name`. For example, when adding the `theme_color` setting, I added a default theme_color of `theme_color: "#58b7ff"` and then added `en.settings.attributes.theme_color.name = "CSS Theme Color"`.
 
-## License 
+## License
 
-Copyright 2017. Copyright shared among all those listed in [CONTRIBUTORS](CONTRIBUTORS.md)  
+Copyright 2017. Copyright shared among all those listed in [CONTRIBUTORS](CONTRIBUTORS.md)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
-    
+
 ## Making a New App
 
 ### Loading Data from transit.land

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>TransitNetwork</title>
+    <title>Caravan</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
     <%= stylesheet_link_tag "application" %>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -2,15 +2,15 @@
 <div class="page-container">
 	<%= stylesheet_link_tag "home" %>
 
-	<h1>About Transit Network</h1>
-	<h4>Transit Network is a platform that democratizes the flow of information about issues that riders encounter on public 
+	<h1>About Caravan</h1>
+	<h4>Caravan is a platform that democratizes the flow of information about issues that riders encounter on public
 	transit.<br /><br  />
 	Utilizing the data provided by major transit systems for modern-day navigation tools (namely, GTFS),
-	Transit Network allows for developers to easily extend open data for schedules and routes in their city, creating a channel 
+	Caravan allows for developers to easily extend open data for schedules and routes in their city, creating a channel
 	for productive expression of transit issues. We hope to empower transit riders to take better advantage of transportatation
  	resources, and push for positive changes in their transit systems.</h4>
 
-	<h4>To learn more about the tech behind this project, visit our <a href="http://github.com/vkoves/Transit-Network">GitHub 
+	<h4>To learn more about the tech behind this project, visit our <a href="https://github.com/CaravanTransit/Caravan-App">GitHub
 	repository</a>.</h4></div>
 
 <%= new_issue_button %>

--- a/config/app.yml
+++ b/config/app.yml
@@ -1,6 +1,6 @@
 # config/app.yml for rails-settings-cached
 defaults: &defaults
-  site_name: "Transit Network"
+  site_name: "Caravan"
   theme_color: "#58b7ff"
 
 development:

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module TransitNetwork
+module Caravan
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "Transit-Network_#{Rails.env}"
+  # config.active_job.queue_name_prefix = "Caravan_#{Rails.env}"
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_Transit-Network_session'
+Rails.application.config.session_store :cookie_store, key: '_Caravan_session'


### PR DESCRIPTION
This pull request refactors the code to fix any references to Transit Network, whether it be in written content or links to GitHub. Take a look!