### PR TITLE
running `rake test` or `rake` will not blow away development db

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -19,7 +19,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   adapter: sqlite3
-  database: db/development.sqlite3
+  database: db/test.sqlite3
   pool: 5
   timeout: 5000
 


### PR DESCRIPTION
Renaming the test db allows data pulled in for local development to persist when across test runs.

I was poking around a things, and noticed that I unexpectedly lost my local data. As it turns out the test and development databases were identical, so running Rake wiped the local db. It seems that running tests should not do that. If someone is building out changes to the UI and wants to run tests making them reload data every time to populate the UI after a test run is going to discourage well-tested code.

Caveat: I'm new to this project, so maybe I'm missing something about how we get tests to play nice with development data.