### PR TITLE
Rubo corrections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
   # Static code analyser
-  gem 'rubocop', '~> 0.53.0'
+  gem 'rubocop', '~> 0.54.0'
   # Used in rubocop config to match official Ruby on Rails settings
   gem 'rubocop-rails', '~> 1.2.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
     parallel (1.12.1)
-    parser (2.5.0.3)
+    parser (2.5.0.5)
       ast (~> 2.4.0)
     powerpack (0.1.1)
     pry (0.10.4)
@@ -197,7 +197,7 @@ GEM
       ffi (>= 0.5.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
-    rubocop (0.53.0)
+    rubocop (0.54.0)
       parallel (~> 1.10)
       parser (>= 2.5)
       powerpack (~> 0.1)
@@ -282,7 +282,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-settings-cached
   rails-settings-ui
-  rubocop (~> 0.53.0)
+  rubocop (~> 0.54.0)
   rubocop-rails (~> 1.2.2)
   sass-rails (~> 5.0)
   simplecov

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class FavoritesController < ApplicationController
   def index
       unless current_user

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class FavoritesController < ApplicationController
   def index
       unless current_user

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -34,7 +34,7 @@ class IssuesController < ApplicationController
 
     respond_to do |format|
       if @issue.save
-        format.html { redirect_to root_path, notice: 'Issue was successfully created.' }
+        format.html { redirect_to root_path, notice: "Issue was successfully created." }
         format.json { render :show, status: :created, location: @issue }
       else
         format.html { render :new }
@@ -48,7 +48,7 @@ class IssuesController < ApplicationController
   def update
     respond_to do |format|
       if @issue.update(issue_params)
-        format.html { redirect_to root_path, notice: 'Issue was successfully updated.' }
+        format.html { redirect_to root_path, notice: "Issue was successfully updated." }
         format.json { render :show, status: :ok, location: @issue }
       else
         format.html { render :edit }
@@ -62,7 +62,7 @@ class IssuesController < ApplicationController
   def destroy
     @issue.destroy
     respond_to do |format|
-      format.html { redirect_to root_path, notice: 'Issue was successfully destroyed.' }
+      format.html { redirect_to root_path, notice: "Issue was successfully destroyed." }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class IssuesController < ApplicationController
   before_action :set_issue, only: [:show, :edit, :update, :destroy]
 

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class IssuesController < ApplicationController
   before_action :set_issue, only: [:show, :edit, :update, :destroy]
 

--- a/app/controllers/lines_controller.rb
+++ b/app/controllers/lines_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class LinesController < ApplicationController
   def index
     @lines = Line.all.sort_by { |l| -l.name.to_i }.sort_by { |l| l.vehicle_type }.reverse!

--- a/app/controllers/lines_controller.rb
+++ b/app/controllers/lines_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class LinesController < ApplicationController
   def index
     @lines = Line.all.sort_by { |l| -l.name.to_i }.sort_by { |l| l.vehicle_type }.reverse!

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class PagesController < ApplicationController
   def dashboard
       if ((params[:lat]) && (params[:long]))

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class PagesController < ApplicationController
   def dashboard
       if ((params[:lat]) && (params[:long]))

--- a/app/controllers/stops_controller.rb
+++ b/app/controllers/stops_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class StopsController < ApplicationController
   def show
     @stop = Stop.find(params[:stop_id])

--- a/app/controllers/stops_controller.rb
+++ b/app/controllers/stops_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class StopsController < ApplicationController
   def show
     @stop = Stop.find(params[:stop_id])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 module ApplicationHelper
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -2,7 +2,7 @@ module IssuesHelper
   def new_issue_button(line: nil, stop: nil)
     line ||= stop&.lines&.first
     link_to(
-      content_tag(:div, '', class: 'create-issue'),
+      content_tag(:div, "", class: "create-issue"),
       new_issue_path(line_id: line&.id, stop_id: stop&.id),
     )
   end

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module IssuesHelper
   def new_issue_button(line: nil, stop: nil)
     line ||= stop&.lines&.first

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module IssuesHelper
   def new_issue_button(line: nil, stop: nil)
     line ||= stop&.lines&.first

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class ApplicationJob < ActiveJob::Base
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
+  default from: "from@example.com"
+  layout "mailer"
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationMailer < ActionMailer::Base
   default from: "from@example.com"
   layout "mailer"

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ApplicationMailer < ActionMailer::Base
   default from: "from@example.com"
   layout "mailer"

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Issue < ApplicationRecord
   belongs_to :user
   belongs_to :stop, foreign_key: "stop_onestop_id"

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Issue < ApplicationRecord
   belongs_to :user
   belongs_to :stop, foreign_key: "stop_onestop_id"

--- a/app/models/line.rb
+++ b/app/models/line.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Line < ApplicationRecord
   has_many :issues, :foreign_key => "line_onestop_id"
   has_and_belongs_to_many :stops, :foreign_key => "line_onestop_id", :association_foreign_key => "stop_onestop_id"

--- a/app/models/line.rb
+++ b/app/models/line.rb
@@ -1,6 +1,6 @@
 class Line < ApplicationRecord
-  has_many :issues, :foreign_key => 'line_onestop_id'
-  has_and_belongs_to_many :stops, :foreign_key => 'line_onestop_id', :association_foreign_key => 'stop_onestop_id'
+  has_many :issues, :foreign_key => "line_onestop_id"
+  has_and_belongs_to_many :stops, :foreign_key => "line_onestop_id", :association_foreign_key => "stop_onestop_id"
 
   self.primary_key = "onestop_id"
 

--- a/app/models/line.rb
+++ b/app/models/line.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Line < ApplicationRecord
   has_many :issues, :foreign_key => "line_onestop_id"
   has_and_belongs_to_many :stops, :foreign_key => "line_onestop_id", :association_foreign_key => "stop_onestop_id"

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # RailsSettings Model
 class Setting < RailsSettings::Base
   source Rails.root.join("config/app.yml")

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # RailsSettings Model
 class Setting < RailsSettings::Base
   source Rails.root.join("config/app.yml")

--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -1,8 +1,8 @@
 class Stop < ApplicationRecord
-  has_many :issues, :foreign_key => 'stop_onestop_id'
-  has_and_belongs_to_many :lines, :foreign_key => 'stop_onestop_id', :association_foreign_key => 'line_onestop_id'
+  has_many :issues, :foreign_key => "stop_onestop_id"
+  has_and_belongs_to_many :lines, :foreign_key => "stop_onestop_id", :association_foreign_key => "line_onestop_id"
   belongs_to :twin_stop, class_name: "Stop", required: false
-  has_and_belongs_to_many :users, :foreign_key => 'stop_onestop_id'
+  has_and_belongs_to_many :users, :foreign_key => "stop_onestop_id"
 
   self.primary_key = "onestop_id"
 

--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Stop < ApplicationRecord
   has_many :issues, :foreign_key => "stop_onestop_id"
   has_and_belongs_to_many :lines, :foreign_key => "stop_onestop_id", :association_foreign_key => "line_onestop_id"

--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Stop < ApplicationRecord
   has_many :issues, :foreign_key => "stop_onestop_id"
   has_and_belongs_to_many :lines, :foreign_key => "stop_onestop_id", :association_foreign_key => "line_onestop_id"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,5 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   has_many :issues
-  has_and_belongs_to_many :favorites, :class_name => 'Stop', :association_foreign_key => 'stop_onestop_id'
+  has_and_belongs_to_many :favorites, :class_name => "Stop", :association_foreign_key => "stop_onestop_id"
 end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Vehicle < ApplicationRecord
   belongs_to :line
 end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Vehicle < ApplicationRecord
   belongs_to :line
 end

--- a/test/controllers/issues_controller_test.rb
+++ b/test/controllers/issues_controller_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # issues_controller_test.rb
 require "test_helper"
 

--- a/test/controllers/issues_controller_test.rb
+++ b/test/controllers/issues_controller_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # issues_controller_test.rb
 require "test_helper"
 

--- a/test/controllers/issues_controller_test.rb
+++ b/test/controllers/issues_controller_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 
 class IssuesControllerTest < ActionDispatch::IntegrationTest
 
-  include Devise::Test::IntegrationHelpers 
+  include Devise::Test::IntegrationHelpers
 
   test "logged in should get issues page" do
     # Sign in user
@@ -13,9 +13,9 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
 
     test_stop_id = "1"
     test_line_id = "1"
-    get new_issue_url, params: {stop_id: test_stop_id, line_id: test_line_id}  
+    get new_issue_url, params: {stop_id: test_stop_id, line_id: test_line_id}
     issue = assigns(:issue)
-    assert_equal test_stop_id, issue.stop_onestop_id 
+    assert_equal test_stop_id, issue.stop_onestop_id
     assert_equal test_line_id, issue.line_onestop_id
     assert_response :success
   end

--- a/test/controllers/issues_controller_test.rb
+++ b/test/controllers/issues_controller_test.rb
@@ -1,5 +1,5 @@
 # issues_controller_test.rb
-require 'test_helper'
+require "test_helper"
 
 class IssuesControllerTest < ActionDispatch::IntegrationTest
 

--- a/test/controllers/lines_controller_test.rb
+++ b/test/controllers/lines_controller_test.rb
@@ -1,5 +1,5 @@
 # lines_controller_test.rb
-require 'test_helper'
+require "test_helper"
 
 class LinesControllerTest < ActionDispatch::IntegrationTest
 

--- a/test/controllers/lines_controller_test.rb
+++ b/test/controllers/lines_controller_test.rb
@@ -5,23 +5,23 @@ require "test_helper"
 
 class LinesControllerTest < ActionDispatch::IntegrationTest
 
-  # Can we get the index page?  
+  # Can we get the index page?
   test "get index page" do
     get lines_url
-    lines = assigns(:lines) 
+    lines = assigns(:lines)
     all_lines = Line.all
-    assert_equal all_lines.size, lines.size 
+    assert_equal all_lines.size, lines.size
     assert_response :success
   end
 
   # Simple test to verify we get the show page when we
   # invoke the page with a valid ID
   test "get show page with valid line id" do
-    param_line = lines(:one) 
+    param_line = lines(:one)
     assert_not_nil param_line
 
-    get line_path(param_line.id) 
-    line = assigns(:line)  
+    get line_path(param_line.id)
+    line = assigns(:line)
     assert_equal param_line.id, line.id
     assert_response :success
   end

--- a/test/controllers/lines_controller_test.rb
+++ b/test/controllers/lines_controller_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # lines_controller_test.rb
 require "test_helper"
 

--- a/test/controllers/lines_controller_test.rb
+++ b/test/controllers/lines_controller_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # lines_controller_test.rb
 require "test_helper"
 

--- a/test/controllers/stops_controller_test.rb
+++ b/test/controllers/stops_controller_test.rb
@@ -1,5 +1,5 @@
 # lines_controller_test.rb
-require 'test_helper'
+require "test_helper"
 
 class StopsControllerTest < ActionDispatch::IntegrationTest
 

--- a/test/controllers/stops_controller_test.rb
+++ b/test/controllers/stops_controller_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # lines_controller_test.rb
 require "test_helper"
 

--- a/test/controllers/stops_controller_test.rb
+++ b/test/controllers/stops_controller_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # lines_controller_test.rb
 require "test_helper"
 

--- a/test/controllers/stops_controller_test.rb
+++ b/test/controllers/stops_controller_test.rb
@@ -8,23 +8,23 @@ class StopsControllerTest < ActionDispatch::IntegrationTest
   # Simple test to verify we get the show page when we
   # invoke the page with a valid ID
   test "get show page with valid stop id" do
-    param_stop = stops(:one) 
+    param_stop = stops(:one)
     assert_not_nil param_stop
 
-    get stop_path(param_stop.id) 
-    stop = assigns(:stop)  
+    get stop_path(param_stop.id)
+    stop = assigns(:stop)
     assert_equal param_stop.id, stop.id
     assert_response :success
   end
 
   # Test to see if invoking the stop show method with an invalid
-  # ID prodcues the expected result  
+  # ID prodcues the expected result
   test "get show page with invalid stop id" do
     invalid_stop_id = -1
     assert_raises ActiveRecord::RecordNotFound do
       get stop_path(invalid_stop_id)
     end
   end
- 
+
 end
 

--- a/test/models/issue_test.rb
+++ b/test/models/issue_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "test_helper"
 
 class IssueTest < ActiveSupport::TestCase

--- a/test/models/issue_test.rb
+++ b/test/models/issue_test.rb
@@ -11,7 +11,7 @@ class IssueTest < ActiveSupport::TestCase
   end
 
   # Verify correct errors are raised if an issue is created
-  # without the proper fields. 
+  # without the proper fields.
   test "invalid without types" do
     line = lines(:one)
     issue = Issue.new(line: line)

--- a/test/models/issue_test.rb
+++ b/test/models/issue_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class IssueTest < ActiveSupport::TestCase

--- a/test/models/issue_test.rb
+++ b/test/models/issue_test.rb
@@ -1,16 +1,16 @@
-require 'test_helper'
+require "test_helper"
 
 class IssueTest < ActiveSupport::TestCase
 
   # Verify issue is valid if correct fields are provided
-  test 'valid issue' do
-    issue = Issue.new(types: 'Cleanliness')
+  test "valid issue" do
+    issue = Issue.new(types: "Cleanliness")
     assert issue.valid?
   end
 
   # Verify correct errors are raised if an issue is created
   # without the proper fields. 
-  test 'invalid without types' do
+  test "invalid without types" do
     line = lines(:one)
     issue = Issue.new(line: line)
     refute issue.valid?

--- a/test/models/line_test.rb
+++ b/test/models/line_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "test_helper"
 
 class LineTest < ActiveSupport::TestCase

--- a/test/models/line_test.rb
+++ b/test/models/line_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class LineTest < ActiveSupport::TestCase

--- a/test/models/line_test.rb
+++ b/test/models/line_test.rb
@@ -6,28 +6,28 @@ class LineTest < ActiveSupport::TestCase
 
   test "returns proper long name" do
     route_long_name = "RouteLong"
-    route_short_name = "RouteShort" 
+    route_short_name = "RouteShort"
     line = Line.new(route_long_name: route_long_name, name: route_short_name)
-    assert_equal route_long_name, line.long_name, "Failed to return correct route long name"  
+    assert_equal route_long_name, line.long_name, "Failed to return correct route long name"
   end
 
   test "returns proper long name if no long name provided" do
-    route_short_name = "RouteShort" 
+    route_short_name = "RouteShort"
     line = Line.new(name: route_short_name)
-    assert_equal route_short_name, line.long_name, "Failed to return correct route long name"  
+    assert_equal route_short_name, line.long_name, "Failed to return correct route long name"
   end
 
   test "returns proper short name" do
     route_long_name = "RouteLong"
-    route_short_name = "RouteShort" 
+    route_short_name = "RouteShort"
     line = Line.new(route_long_name: route_long_name, name: route_short_name)
-    assert_equal route_short_name, line.short_name, "Failed to return correct route short name"  
+    assert_equal route_short_name, line.short_name, "Failed to return correct route short name"
   end
 
   test "returns proper short name if no short name provided" do
     route_long_name = "RouteLong"
     line = Line.new(route_long_name: route_long_name)
-    assert_nil line.short_name, "Failed to return correct route short name"  
+    assert_nil line.short_name, "Failed to return correct route short name"
   end
 
 end

--- a/test/models/line_test.rb
+++ b/test/models/line_test.rb
@@ -1,28 +1,28 @@
-require 'test_helper'
+require "test_helper"
 
 class LineTest < ActiveSupport::TestCase
 
-  test 'returns proper long name' do
+  test "returns proper long name" do
     route_long_name = "RouteLong"
     route_short_name = "RouteShort" 
     line = Line.new(route_long_name: route_long_name, name: route_short_name)
     assert_equal route_long_name, line.long_name, "Failed to return correct route long name"  
   end
 
-  test 'returns proper long name if no long name provided' do
+  test "returns proper long name if no long name provided" do
     route_short_name = "RouteShort" 
     line = Line.new(name: route_short_name)
     assert_equal route_short_name, line.long_name, "Failed to return correct route long name"  
   end
 
-  test 'returns proper short name' do
+  test "returns proper short name" do
     route_long_name = "RouteLong"
     route_short_name = "RouteShort" 
     line = Line.new(route_long_name: route_long_name, name: route_short_name)
     assert_equal route_short_name, line.short_name, "Failed to return correct route short name"  
   end
 
-  test 'returns proper short name if no short name provided' do
+  test "returns proper short name if no short name provided" do
     route_long_name = "RouteLong"
     line = Line.new(route_long_name: route_long_name)
     assert_nil line.short_name, "Failed to return correct route short name"  

--- a/test/models/stop_test.rb
+++ b/test/models/stop_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class StopTest < ActiveSupport::TestCase
 

--- a/test/models/stop_test.rb
+++ b/test/models/stop_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "test_helper"
 
 class StopTest < ActiveSupport::TestCase

--- a/test/models/stop_test.rb
+++ b/test/models/stop_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class StopTest < ActiveSupport::TestCase

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase

--- a/test/rails_helper.rb
+++ b/test/rails_helper.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+
 config.include Devise::Test::IntegrationHelpers, type: :feature
 

--- a/test/rails_helper.rb
+++ b/test/rails_helper.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 config.include Devise::Test::IntegrationHelpers, type: :feature
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 # Add Coveralls
-require 'simplecov'
-require 'coveralls'
+require "simplecov"
+require "coveralls"
 Coveralls.wear!
 
 SimpleCov.start do
@@ -8,9 +8,9 @@ SimpleCov.start do
   add_filter "/config/"
 end
 
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
-require 'rails/test_help'
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../../config/environment", __FILE__)
+require "rails/test_help"
 
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Add Coveralls
 require "simplecov"
 require "coveralls"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Add Coveralls
 require "simplecov"
 require "coveralls"


### PR DESCRIPTION
Now that we have rubocop in available and configured to an acceptable standard it is a good time to revise files to match that standard. Rubocop's `--auto-correct` flag is a great way to mass update files.

In order to keep this PR's scope reasonable didn't update everything at once, and instead just corrected the top 3 offenders:

```
36   Style/StringLiterals
28   Style/FrozenStringLiteralComment
22   Layout/TrailingWhitespace
```

If these look good this I can tackle what is left in another PR. Here is what would remains after this one:

```
bundle exec rubocop --format offenses --out ~/offenses.txt 'app/**/*.rb' 'lib/**/*.rb' 'test/**/*.rb'

16  Style/HashSyntax
11  Layout/EmptyLinesAroundClassBody
5   Layout/IndentationWidth
5   Layout/TrailingBlankLines
5   Metrics/LineLength
2   Layout/SpaceInsideHashLiteralBraces
1   Layout/SpaceAfterComma
--
45  Total
```