### PR TITLE
Add City Name Site Setting & Style Global Messages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,17 @@ a {
 	color: #0091ff;
 }
 
+// Style global messages
+.global-msg {
+	padding: 1rem;
+	color: #ffffff;
+
+	// Negative messages, like you are already signed in
+	&.-alert { background-color: #f44336; }
+	// Positive messages, like you've signed in
+	&.-notice { background-color: #4caf50; }
+}
+
 body > a > .create-issue {
 	position: fixed;
 	height: 40px;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,10 +27,14 @@
   	<%= render "shared/header" %>
 
     <% if notice %>
-      <p class="notice"><%= notice %></p>
+      <div class="global-msg -notice">
+        <%= notice %>
+      </div>
     <% end %>
     <% if alert %>
-      <p class="alert"><%= alert %></p>
+      <div class="global-msg -alert">
+        <%= alert %>
+      </div>
     <% end %>
 
     <% if current_user %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -4,8 +4,7 @@
 
     <div class="heading">
       Report and View Public Transit Issues in
-      <% # TODO: Make this print a setting city name %>
-      <%= "Chicago" %>
+      <%= Setting.city_name %>
     </div>
 
     <%= link_to('Learn More', page_path(:page_name => 'about'), :class => 'simple-btn') %>

--- a/config/app.yml
+++ b/config/app.yml
@@ -1,7 +1,10 @@
 # config/app.yml for rails-settings-cached
+
+# These are the defaults for the site settings
 defaults: &defaults
   site_name: "Caravan"
   theme_color: "#58b7ff"
+  city_name: "Our City"
 
 development:
   <<: *defaults

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,9 +20,10 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
   settings:
     attributes:
+      city_name:
+        name: "City/Municipality Name"
       site_name:
         name: "Site Name"
       theme_color:


### PR DESCRIPTION
### Description of Changes:

This removes the hard-coded "Chicago" reference on the homepage, and instead makes it pull from a city name site setting that defaults to "Our City". When this is deployed, we'll need to update the setting on the live app to "Chicago", but this will prevent any hard-coded CTA specific language.

This also styles global messages to be clearer so that Rails messages from Caravan are intuitive. Here's some screenshots:

| Alert (Negative) | Notice (Positive) |
| --- | --- |
| ![screenshot from 2018-10-16 20-08-11](https://user-images.githubusercontent.com/3187531/47055899-5a401100-d17f-11e8-807b-7862324fbba1.png) | ![screenshot from 2018-10-16 20-07-52](https://user-images.githubusercontent.com/3187531/47055900-5a401100-d17f-11e8-9e28-c1d341fb9178.png) |


### How This Was Tested:

Manual testing by signing in to see a positive message, then clicking sign in after refreshing to see a negative message. Also update the site setting to confirm the city name works properly.

### Related Issue(s) or Specifications:
- None
<!--- To automatically close related issue(s) on merge, put "Closes #<issue number>" in the list above -->

### Checklist:
- [x] Code follows code style of this project
- [x] Tests added to cover changes
- [x] All new and existing tests passing

### Questions / Additional Notes:
