### PR TITLE
Improve Desktop Header and General Form Styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,7 +22,11 @@ body {
 	font-size: 1.2em;
 }
 .page-container {
-	margin: 0px 15px;
+	max-width: $max-width-page;
+	margin: auto;
+	padding: 0px $page-padding;
+
+	&.-thin { max-width: 600px; }
 }
 
 a {
@@ -33,12 +37,12 @@ a {
 // Style global messages
 .global-msg {
 	padding: 1rem;
-	color: #ffffff;
 
 	// Negative messages, like you are already signed in
 	&.-alert { background-color: #f44336; }
 	// Positive messages, like you've signed in
 	&.-notice { background-color: #4caf50; }
+	* { color: #ffffff; }
 }
 
 body > a > .create-issue {

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -8,14 +8,18 @@
 }
 
 input[type="submit"].pill {
-  font-size: 16px;
-  border-radius: 80px;
-  background-color: #6cbfff;
-  color: white;
-  height: 40px;
-  margin-top:15px;
-  width: 100%;
-  border: none;
   font-family:"Open Sans", "Segoe UI", sans-serif;
   font-weight:600;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 10px 30px;
+  border-radius: 5px;
+  background-color: #6cbfff;
+  margin-top: 15px;
+  color: white;
+  border: none;
+
+  &:hover, &:focus {
+    background-color: #52b4ff;
+  }
 }

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -5,6 +5,12 @@
 	width: 100%;
 	background-color: $theme-color;
 	text-align: center;
+
+	.header-inner {
+		margin: auto;
+		max-width: $max-width-page;
+		padding: 0 $page-padding;
+	}
 }
 
 .hamburger {

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -165,7 +165,6 @@ h6 {
 		text-align: left;
 		height: auto;
 		box-sizing: border-box;
-		padding: 0px 20px;
 
 		.desktop-links { padding: 10px 0px; }
 		ul { display: flex; }

--- a/app/assets/stylesheets/lines.scss
+++ b/app/assets/stylesheets/lines.scss
@@ -3,17 +3,18 @@
 	background-image: url(asset-path('train.jpg'));
 	background-size: 100%;
 	width: 100%;
-	height: 100px;
+	min-height: 100px;
+	height: 12vw;
 	background-position: center;
 
+	* { color: white; }
 	h3 {
 		position: absolute;
 		width: 100%;
 		bottom: 0px;
 		box-sizing: border-box;
-		color: white;
 		background-color: rgba(0,0,0,0.7);
-		padding: 8px 20px;
+		padding: 8px 0px;
 		margin: 0px;
 	}
 }
@@ -30,7 +31,6 @@
 	li {
 		display: table;
 		height: 40px;
-		margin-left: 10px;
 
 		.line-mark {
 			position: relative;
@@ -44,7 +44,7 @@
 				height: 100%;
 				left: 12px;
 				background: #535353;
-			} 
+			}
 			.mark-circle {
 				background: white;
 				width: 10px;
@@ -97,7 +97,7 @@
 .stop-title {
 	.line-tile {
 		display: inline-block;
-	
+
 		&:first-of-type { margin-left: 5px; }
 		.api-id, .line-swatch { font-size: 12px; }
 	}

--- a/app/assets/stylesheets/loginFields.scss
+++ b/app/assets/stylesheets/loginFields.scss
@@ -1,75 +1,24 @@
-.field-login {
-
-	height: 60px;
+input#user_email, input#user_password, input#user_password_confirmation {
+	box-sizing: border-box;
 	width: 100%;
-	background-color: white;
-	padding-bottom:20px;
-	padding-top:14px;
-
-}
-
-input#user_email, input#user_password, input#user_password_confirmation{
-
-	height: 24px;
-	width: 100%;
-	/*outline-style: none;*/
-	border: 1px #777 solid;
+	max-width: 600px;
+	padding: 10px;
+	cursor: auto;
+	font-size: 1rem;
+	border-radius: 5px;
+	border: 1px #d6d6d6 solid;
 	box-shadow: none;
-	margin-top:14px;
-	margin-bottom:4px;
+	margin-top: 15px;
+	margin-bottom: 5px;
 	background-color: #f1f1f1;
-
-}
-
-#devise-title {
-	font-size:24px;
-	/*padding:10px;*/
-	/*padding-top:10px;*/
-	/*float:left;*/
-	margin:0;
-	/*padding-left: 5%;*/
-	display: inline-block;
-	padding:0px;
-}
-
-.remember {
-	float:left;
- }
-
-.field-login label {
-	font-size: 15px;
-	float: right;
-	padding-top:10px;
-	display:inline-block;
-}
-
-
-
-
-label.check-label {
-
-	float: left;
-}
-
-form.new_user {
-	margin-left: 5%;
-	margin-right: 5%;
-}
-
-#new_user > div:nth-child(5) {
-	height: 30px;
-}
-
-#devise-title {
-	padding-left: 5%;
 }
 
 .login-link {
 	text-decoration: none;
-	color:#6cbfff;
+	color: #0076d1;
+
+	&:hover, &:focus { text-decoration: underline; }
 }
-
-
 
 #signin-options {
 	padding-top:15px;

--- a/app/assets/stylesheets/variables.scss.erb
+++ b/app/assets/stylesheets/variables.scss.erb
@@ -3,3 +3,5 @@ $theme-color: <%= Setting.theme_color %>;
 
 /** Other Variables **/
 $header-height: 50px;
+$max-width-page: 1200px;
+$page-padding: 15px;

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,18 @@
-<h2>Forgot your password?</h2>
+<div class="page-container -thin">
+	<h2>Forgot your password?</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+	<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+	  <%= devise_error_messages! %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
-  </div>
+	  <div class="field">
+	    <%= f.label :email %><br />
+	    <%= f.email_field :email, autofocus: true %>
+	  </div>
 
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions", :class => 'pill' %>
-  </div>
-<% end %>
+	  <div class="actions">
+	    <%= f.submit "Send me reset password instructions", :class => 'pill' %>
+	  </div>
+	<% end %>
 
-<%= render "devise/shared/links" %>
+	<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,10 +1,10 @@
-<div class="page-container">
-  <!-- <h2>Sign Up</h2> -->
+<div class="page-container -thin">
+  <h2 id="devise-title">Sign Up</h2>
+
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= devise_error_messages! %>
 
     <div class="field-label">
-      <h2 id="devise-title">Sign Up</h2>
       <%= f.label :email %><br />
       <%= f.email_field :email, autofocus: true %>
     </div>
@@ -21,11 +21,11 @@
       <%= f.label :password_confirmation %><br />
       <%= f.password_field :password_confirmation, autocomplete: "off" %>
     </div>
-    <br />
-  <div class="actions">
-    <%= f.submit "Sign Up", :class => 'pill' %>
-  </div>
-<% end %>
+
+    <div class="actions">
+      <%= f.submit "Sign Up", :class => 'pill' %>
+    </div>
+  <% end %>
 
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,22 +1,21 @@
+<div class="page-container -thin">
+  <h2 id="devise-title">Sign In</h2>
 
-<!-- <h2 id="devise-title">Sign In</h2> -->
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <div class="field-label">
+      <%= f.label :email %><br />
+      <%= f.email_field :email, autofocus: true %>
+    </div>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field-label">
-    <h2 id="devise-title">Sign In</h2>
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
-  </div>
-
-  <div class="field-label">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
+    <div class="field-label">
+      <%= f.label :password %><br />
+      <%= f.password_field :password, autocomplete: "off" %>
+    </div>
 
     <div class="actions">
       <%= f.submit "Log in", :class => 'pill' %>
     </div>
-<% end %>
+  <% end %>
 
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,12 +28,16 @@
 
     <% if notice %>
       <div class="global-msg -notice">
-        <%= notice %>
+        <div class="page-container">
+          <%= notice %>
+        </div>
       </div>
     <% end %>
     <% if alert %>
       <div class="global-msg -alert">
-        <%= alert %>
+        <div class="page-container">
+          <%= alert %>
+        </div>
       </div>
     <% end %>
 

--- a/app/views/lines/show.html.erb
+++ b/app/views/lines/show.html.erb
@@ -1,26 +1,30 @@
 <div class="line-cover">
 	<h3>
-		<%= @line.long_name %>
-		<% if @line.short_name %>
-			(<%= @line.short_name %>)
-		<% end %>
+		<div class="page-container">
+			<%= @line.long_name %>
+			<% if @line.short_name %>
+				(<%= @line.short_name %>)
+			<% end %>
+		</div>
 	</h3>
 </div>
-<ul class="stop-list">
-	<% @line.stops.each do |stop| %>
-		<li class="stop">
-			<div class="line-mark">
-				<% if @line.color %>
-					<div class="mark-box" style="background: #<%= @line.color %>"></div>
-					<div class="mark-circle" style="border-color: #<%= @line.color %>"></div>
-				<% else %>
-					<div class="mark-box"></div>
-					<div class="mark-circle"></div>
-				<% end %>
-			</div>
-			<%= render "stops/show", stop: stop, current_line: @line %>
-		</li>
-	<% end %>
-</ul>
+<div class="page-container">
+	<ul class="stop-list">
+		<% @line.stops.each do |stop| %>
+			<li class="stop">
+				<div class="line-mark">
+					<% if @line.color %>
+						<div class="mark-box" style="background: #<%= @line.color %>"></div>
+						<div class="mark-circle" style="border-color: #<%= @line.color %>"></div>
+					<% else %>
+						<div class="mark-box"></div>
+						<div class="mark-circle"></div>
+					<% end %>
+				</div>
+				<%= render "stops/show", stop: stop, current_line: @line %>
+			</li>
+		<% end %>
+	</ul>
+</div>
 
 <%= new_issue_button(line: @line) %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,11 +1,13 @@
 <header class="headbar">
-	<div class="hamburger"></div>
-	<a href="/">
-		<div class="title"><%= Setting.site_name %></div>
-	</a>
-	<div class= "search"></div>
-	<div class="desktop-links">
-		<%= render "shared/header-links" %>
+	<div class="header-inner">
+		<div class="hamburger"></div>
+		<a href="/">
+			<div class="title"><%= Setting.site_name %></div>
+		</a>
+		<div class= "search"></div>
+		<div class="desktop-links">
+			<%= render "shared/header-links" %>
+		</div>
 	</div>
 </header>
 


### PR DESCRIPTION
### Description of Changes:

This pull request fixes issues with the Devise forms looking bad on desktop, and generally improves them for all devices. It also makes it so that the page content and header are restricted to 1200px on desktop, to make content centered. Forms are centered at 600px width.

Additionally, I updated the styling so form inputs are a little more padded and rounded, "pill" buttons now are not pills (it just didn't fit everything else), and making the simple links WCAG 2.0 AA contrast compliant as well as having a hover effect on all links.

### Screenshots

Here are some comparison screenshots, with the before screenshot first.

#### Sign In (Mobile)

| Before | After |
| --- | --- |
| ![screenshot from 2018-11-20 20-24-46](https://user-images.githubusercontent.com/3187531/48814958-5e24fd00-ed02-11e8-82c5-ad67286e06a2.png) | ![screenshot from 2018-11-20 20-24-54](https://user-images.githubusercontent.com/3187531/48814957-5e24fd00-ed02-11e8-8ebb-1fee910ec3a5.png) |

### Sign In (Desktop) 
![screenshot from 2018-11-20 20-26-52](https://user-images.githubusercontent.com/3187531/48815044-a8a67980-ed02-11e8-8240-08a7c7a35733.png)

![screenshot from 2018-11-20 20-26-45](https://user-images.githubusercontent.com/3187531/48815045-a8a67980-ed02-11e8-88b2-196d237d9556.png)


### How This Was Tested:

Manually tested on Chrome using desktop and mobile emulator.

### Related Issue(s) or Specifications:

- #109 

### Checklist:
- [x] Code follows code style of this project
- [ ] Tests added to cover changes
- [x] All new and existing tests passing

### Questions / Additional Notes:
